### PR TITLE
gitignore for the .temp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#ignore the .temp folder created by the binarizer
+.temp/


### PR DESCRIPTION
ignores the folder created by the binarizer
